### PR TITLE
11 save input parameters to dff

### DIFF
--- a/code/dff.py
+++ b/code/dff.py
@@ -171,9 +171,9 @@ if __name__ == "__main__":
         f.create_dataset("skewness", data=skewness)
 
     # Include settings in metadata
-    metadata = {**vars(args), **settings.dict()}
+    input_params = {**vars(args)}
     write_data_process(
-        metadata,
+        input_params,
         extraction_fp,
         output_dir / "dff.h5",
         experiment_id,

--- a/code/dff.py
+++ b/code/dff.py
@@ -17,31 +17,31 @@ from scipy.stats import skew
 
 class DFFSettings(BaseSettings, cli_parse_args=True):
     """Settings for DF/F calculation parameters"""
-    
+
     input_dir: Path = Field(
         default="/data",
-        description="Input directory containing raw movies and metadata files"
+        description="Input directory containing raw movies and metadata files",
     )
     output_dir: Path = Field(
-        default="/results",
-        description="Output director where to save results to"
+        default="/results", description="Output director where to save results to"
     )
-    long_window : int = Field(
-        default=60,
-        description="Moving window size (in seconds) of the rolling percentile filter used to compute a rolling baseline"
+    long_window: int = Field(
+        default=1800,
+        description="Moving window size (in seconds) of the rolling percentile filter used to compute a rolling baseline",
     )
-    short_window : float = Field(
+    short_window: float = Field(
         default=3.333,
-        description="Moving window size (in seconds) of the median filter to compute the rolling median-filtered signal, which is subtracted from the input 'F' for noise_method=mad"
+        description="Moving window size (in seconds) of the median filter to compute the rolling median-filtered signal, which is subtracted from the input 'F' for noise_method=mad",
     )
-    inactive_percentile : int = Field(
+    inactive_percentile: int = Field(
         default=10,
-        description="Percentile value that defines the inactive frames used for calculating the baseline"
+        description="Percentile value that defines the inactive frames used for calculating the baseline",
     )
-    noise_method : str = Field(
+    noise_method: str = Field(
         default="mad",
-        description="Method for computing the noise, see ..signal_utils.noise_stdChoices: 'mad', 'fft', 'welch'"
+        description="Method for computing the noise, see ..signal_utils.noise_stdChoices: 'mad', 'fft', 'welch'",
     )
+
     class Config:
         env_prefix = "DFF_"
 
@@ -159,7 +159,7 @@ if __name__ == "__main__":
             long_window=args.long_window,
             short_window=args.short_window,
             inactive_percentile=args.inactive_percentile,
-            noise_method=args.noise_method
+            noise_method=args.noise_method,
         )
     else:  # no ROIs detected
         dff_traces, baseline, noise = traces, traces, []

--- a/code/dff.py
+++ b/code/dff.py
@@ -136,7 +136,7 @@ def make_output_directory(output_dir: Path, experiment_id: str) -> str:
 
 
 if __name__ == "__main__":
-    star_time = dt.now()
+    start_time = dt.now()
     args = DFFSettings()
     input_dir = args.input_dir
     output_dir = args.output_dir

--- a/code/dff.py
+++ b/code/dff.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
     subject_data = get_metadata(input_dir, "subject.json")
     subject_id = subject_data.get("subject_id", "")
     setup_logging("aind-ophys-dff", mouse_id=subject_id, session_name=name)
-    extraction_dir = next(input_dir.glob("*/extraction"))
+    extraction_dir = next(input_dir.rglob("*/extraction"))
     experiment_id = extraction_dir.parent.name
     logging.info(f"Calculating dF/F for ExperimentID {experiment_id}")
     extraction_fp = next(extraction_dir.glob("*extraction.h5"))

--- a/code/dff.py
+++ b/code/dff.py
@@ -10,7 +10,40 @@ import aind_ophys_utils.dff as dff
 import h5py
 from aind_data_schema.core.processing import DataProcess, ProcessName
 from aind_log_utils.log import setup_logging
+from pydantic import Field
+from pydantic_settings import BaseSettings
 from scipy.stats import skew
+
+
+class DFFSettings(BaseSettings, cli_parse_args=True):
+    """Settings for DF/F calculation parameters"""
+    
+    input_dir: Path = Field(
+        default="/data",
+        description="Input directory containing raw movies and metadata files"
+    )
+    output_dir: Path = Field(
+        default="/results",
+        description="Output director where to save results to"
+    )
+    long_window : int = Field(
+        default=60,
+        description="Moving window size (in seconds) of the rolling percentile filter used to compute a rolling baseline"
+    )
+    short_window : float = Field(
+        default=3.333,
+        description="Moving window size (in seconds) of the median filter to compute the rolling median-filtered signal, which is subtracted from the input 'F' for noise_method=mad"
+    )
+    inactive_percentile : int = Field(
+        default=10,
+        description="Percentile value that defines the inactive frames used for calculating the baseline"
+    )
+    noise_method : str = Field(
+        default="mad",
+        description="Method for computing the noise, see ..signal_utils.noise_stdChoices: 'mad', 'fft', 'welch'"
+    )
+    class Config:
+        env_prefix = "DFF_"
 
 
 def write_data_process(
@@ -103,17 +136,10 @@ def make_output_directory(output_dir: Path, experiment_id: str) -> str:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-i", "--input-dir", type=str, help="Input directory", default="/data/"
-    )
-    parser.add_argument(
-        "-o", "--output-dir", type=str, help="Output directory", default="/results/"
-    )
-    start_time = dt.now()
-    args = parser.parse_args()
-    input_dir = Path(args.input_dir).resolve()
-    output_dir = Path(args.output_dir).resolve()
+
+    args = DFFSettings()
+    input_dir = args.input_dir
+    output_dir = args.output_dir
     data_description_data = get_metadata(input_dir, "data_description.json")
     name = data_description_data.get("name", "")
     subject_data = get_metadata(input_dir, "subject.json")
@@ -127,7 +153,14 @@ if __name__ == "__main__":
     with h5py.File(extraction_fp, "r") as f:
         traces = f["traces/corrected"][()]
     if len(traces):
-        dff_traces, baseline, noise = dff.dff(traces)
+        # Pass settings parameters to the dff function
+        dff_traces, baseline, noise = dff.dff(
+            traces,
+            long_window=args.long_window,
+            short_window=args.short_window,
+            inactive_percentile=args.inactive_percentile,
+            noise_method=args.noise_method
+        )
     else:  # no ROIs detected
         dff_traces, baseline, noise = traces, traces, []
     skewness = skew(dff_traces, axis=1)
@@ -137,8 +170,10 @@ if __name__ == "__main__":
         f.create_dataset("noise", data=noise)
         f.create_dataset("skewness", data=skewness)
 
+    # Include settings in metadata
+    metadata = {**vars(args), **settings.dict()}
     write_data_process(
-        vars(args),
+        metadata,
         extraction_fp,
         output_dir / "dff.h5",
         experiment_id,

--- a/code/dff.py
+++ b/code/dff.py
@@ -136,7 +136,7 @@ def make_output_directory(output_dir: Path, experiment_id: str) -> str:
 
 
 if __name__ == "__main__":
-
+    star_time = dt.now()
     args = DFFSettings()
     input_dir = args.input_dir
     output_dir = args.output_dir

--- a/code/dff.py
+++ b/code/dff.py
@@ -26,7 +26,7 @@ class DFFSettings(BaseSettings, cli_parse_args=True):
         default="/results", description="Output director where to save results to"
     )
     long_window: int = Field(
-        default=1800,
+        default=60,
         description="Moving window size (in seconds) of the rolling percentile filter used to compute a rolling baseline",
     )
     short_window: float = Field(

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -20,4 +20,6 @@ RUN pip3 install -U --no-cache-dir \
 RUN pip3 install -U --no-cache-dir \
     aind-ophys-utils==0.0.7 \
     aind-data-schema==1.1.0 \
-    aind-log-utils
+    aind-log-utils \
+    pydantic \
+    pydantic_settings


### PR DESCRIPTION
Add `BaseSettings` class to parse and validate command line args. Expose parameters that were previously inaccessible to users.