### PR TITLE
refactor: delegate dF/F plotting to aind-ophys-utils

### DIFF
--- a/code/dff.py
+++ b/code/dff.py
@@ -132,7 +132,7 @@ def compute_dff(
     traces: np.ndarray,
     settings: "DFFSettings",
     frame_rate: float,
-    ts: Optional[np.ndarray],
+    ts: np.ndarray | None,
     n_jobs: int,
 ) -> tuple:
     """Dispatch to the selected dF/F algorithm; return a uniform 5-tuple.

--- a/code/dff.py
+++ b/code/dff.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime as dt
 from multiprocessing import Pool
 from pathlib import Path
-from typing import Union
 
 import aind_ophys_utils.dff as dff
 import h5py
@@ -24,8 +23,6 @@ from aind_data_schema.core.quality_control import (
 from aind_data_schema_models.modalities import Modality
 from aind_log_utils.log import setup_logging
 from aind_qcportal_schema.metric_value import CurationMetric
-# from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
-from numpy.typing import NDArray
 from pydantic import Field
 from pydantic_settings import BaseSettings
 from scipy.stats import skew
@@ -68,8 +65,8 @@ class DFFSettings(BaseSettings, cli_parse_args=True):
 
 def write_data_process(
     metadata: dict,
-    input_fp: Union[str, Path],
-    output_fp: Union[str, Path],
+    input_fp: str | Path,
+    output_fp: str | Path,
     unique_id: str,
     start_time: dt,
     end_time: dt,
@@ -181,172 +178,9 @@ def get_frame_rate(session: dict) -> float:
     return frame_rate_hz
 
 
-# def plot_dff(
-#     trace: NDArray,
-#     baseline: NDArray,
-#     dff_trace: NDArray,
-#     frame_rate: float,
-#     roi_id: int,
-#     fig_path: Union[str, Path],
-#     unique_id: str,
-#     zoom_duration: float = 60.0,
-# ) -> None:
-#     """Plot raw and dF/F traces with optional zoomed insets.
-
-#     Creates a multi-panel plot showing raw fluorescence signal and baseline-corrected
-#     dF/F trace. When zoom_duration is specified, includes three zoomed inset plots
-#     showing detailed views of the beginning, middle, and end of the recording session.
-
-#     Parameters
-#     ----------
-#     trace : NDArray
-#         Neuropil-corrected raw fluorescence trace
-#     baseline : NDArray
-#         Fitted baseline (F0) values
-#     dff_trace : NDArray
-#         Baseline-corrected dF/F trace (fractional units)
-#     frame_rate : float
-#         Frame rate in Hz
-#     roi_id : int
-#         Region of interest identifier for labeling the plot
-#     fig_path : str or Path
-#         Directory path where the output PNG file will be saved
-#     unique_id: str
-#         unique identifier
-#     zoom_duration : float, optional
-#         Duration in seconds for each zoomed inset window. If None or 0,
-#         creates a simpler 2-row layout without insets. If positive, creates
-#         a 3-row layout with inset zoom plots. Default is 60.0.
-
-#     Returns
-#     -------
-#     None
-#         Saves the plot as a PNG file to the specified path and closes the figure.
-
-#     Notes
-#     -----
-#     The function creates different layouts based on zoom_duration:
-
-#     - If zoom_duration is None or 0: 2 rows per channel (raw + dF/F)
-#     - If zoom_duration > 0: 3 rows per channel (raw + insets + dF/F)
-
-#     Inset windows show:
-#     - First: Beginning of recording (0 to zoom_duration seconds)
-#     - Middle: Center portion of recording
-#     - Last: End of recording (last zoom_duration seconds)
-
-#     The saved filename follows the pattern: '{unique_id}_{roi_id}_dff.png'
-#     """
-#     t = np.arange(len(trace)) / frame_rate
-#     show_insets = zoom_duration is not None and zoom_duration > 0
-
-#     # Create figure and axes
-#     if show_insets:
-#         fig, ax = plt.subplots(3, 1, figsize=(12, 3.5))
-#     else:
-#         fig, ax = plt.subplots(2, 1, figsize=(12, 2.3), sharex=True)
-
-#     # Calculate row indices based on layout
-#     raw_idx = 0
-#     dff_idx = 2 if show_insets else 1
-#     inset_idx = 1 if show_insets else None
-
-#     # Plot raw signal
-#     ax[raw_idx].plot(t, trace, label="neuropil-corrected trace", c="C0", lw=0.5)
-#     ax[raw_idx].plot(t, baseline, label=r"fitted F$_0$", c="#F0E442")
-#     ax[raw_idx].legend(
-#         loc=(0.692, 0.78), ncol=2, borderpad=0.05
-#     ).get_frame().set_linewidth(0.0)
-#     ax[raw_idx].set_ylabel("F [a.u.]")
-
-#     # Plot dF/F signal
-#     ax[dff_idx].plot(t, dff_trace * 100, label=r"$\Delta$F/F", c="C2", zorder=-1, lw=0.5)
-#     ax[dff_idx].axhline(0, c="k", ls="--")
-#     ax[dff_idx].legend(
-#         loc=(0.923, 0.78), ncol=1, borderpad=0.05
-#     ).get_frame().set_linewidth(0.0)
-#     ax[dff_idx].set_ylabel(r"$\Delta$F/F [%]", y=1 if show_insets else 0.5)
-
-#     # Add insets if requested
-#     if show_insets:
-#         t_total = t[-1] - t[0]
-#         zoom_windows = [
-#             (t[0], t[0] + zoom_duration),
-#             (
-#                 t[0] + (t_total - zoom_duration) / 2,
-#                 t[0] + (t_total + zoom_duration) / 2,
-#             ),
-#             (max(t[-1] - zoom_duration, t[0]), t[-1]),
-#         ]
-
-#         ax[inset_idx].axis("off")
-
-#         for j, (start_time, end_time) in enumerate(zoom_windows):
-#             inset_ax = inset_axes(
-#                 ax[inset_idx],
-#                 width="100%",
-#                 height="100%",
-#                 loc="center",
-#                 bbox_to_anchor=([0.01, 0.34, 0.67][j], 0.0, 0.32, 0.8),
-#                 bbox_transform=ax[inset_idx].transAxes,
-#             )
-
-#             mask = (t >= start_time) & (t <= end_time)
-#             if np.any(mask):
-#                 t_zoom, dff_zoom = t[mask], dff_trace[mask] * 100
-
-#                 inset_ax.plot(t_zoom, dff_zoom, c="C2", lw=0.5)
-#                 inset_ax.axhline(0, c="k", ls="--")
-#                 inset_ax.grid(True, alpha=0.8)
-#                 inset_ax.set_xlim(start_time, end_time)
-
-#                 if len(dff_zoom) > 0:
-#                     mi, ma = np.nanmin(dff_zoom), np.nanmax(dff_zoom)
-#                     y_margin = 0.1 * (ma - mi)
-#                     if ~np.isnan(y_margin):
-#                         inset_ax.set_ylim(mi - y_margin, ma + y_margin)
-
-#                 inset_ax.set_title(
-#                     f"{['First', 'Middle', 'Last'][j]} {zoom_duration:.0f}s",
-#                     fontsize=10,
-#                     y=0.94,
-#                 )
-#                 inset_ax.set_xticks([])
-#                 inset_ax.set_yticks([])
-
-#                 mark_inset(
-#                     ax[dff_idx],
-#                     inset_ax,
-#                     loc1=1,
-#                     loc2=3,
-#                     fc="none",
-#                     ec="#333333",
-#                     alpha=0.8,
-#                     linestyle="--",
-#                     linewidth=1,
-#                 )
-
-#     # Set x-limits and labels
-#     tmin, tmax = np.nanmin(t), np.nanmax(t)
-#     margin = (tmax - tmin) / 100
-#     ax[raw_idx].set_xlim(tmin - margin, tmax + margin)
-#     ax[dff_idx].set_xlim(tmin - margin, tmax + margin)
-#     plt.setp(ax[raw_idx].get_xticklabels(), visible=False)
-#     ax[dff_idx].set_xlabel("Time [s]")
-#     ax[0].set_title(f"cell_roi_id: {int(roi_id)}")
-#     plt.subplots_adjust(hspace=0.1, top=0.935, bottom=0.13, left=0.06, right=0.995)
-#     fig.savefig(
-#         fig_path / f"{unique_id}_{roi_id}_dff.png",
-#         dpi=200,
-#         bbox_inches="tight",
-#         pad_inches=0.02,
-#     )
-#     plt.close(fig)
-
-
 def plot_dff(
-    trace: NDArray,
-    baseline: NDArray,
+    trace: np.ndarray,
+    baseline: np.ndarray,
     frame_rate: float,
     roi_id: int,
     fig_path: str | Path,
@@ -358,8 +192,6 @@ def plot_dff(
     frame-rate-to-time conversion, triexp log annotation, and saving to disk."""
     t = np.arange(len(trace)) / frame_rate
     fig = dff.plot_dff(trace, baseline, t, zoom_duration=zoom_duration, roi_id=roi_id)
-    fig.set_size_inches(12, 3.5 if zoom_duration else 2.3)
-    fig.axes[0].get_lines()[1].set_color("#F0E442")
     title = f"cell_roi_id: {int(roi_id)}"
     if log is not None:
         title += (

--- a/code/dff.py
+++ b/code/dff.py
@@ -24,7 +24,7 @@ from aind_data_schema.core.quality_control import (
 from aind_data_schema_models.modalities import Modality
 from aind_log_utils.log import setup_logging
 from aind_qcportal_schema.metric_value import CurationMetric
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
+# from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
 from numpy.typing import NDArray
 from pydantic import Field
 from pydantic_settings import BaseSettings
@@ -181,162 +181,195 @@ def get_frame_rate(session: dict) -> float:
     return frame_rate_hz
 
 
+# def plot_dff(
+#     trace: NDArray,
+#     baseline: NDArray,
+#     dff_trace: NDArray,
+#     frame_rate: float,
+#     roi_id: int,
+#     fig_path: Union[str, Path],
+#     unique_id: str,
+#     zoom_duration: float = 60.0,
+# ) -> None:
+#     """Plot raw and dF/F traces with optional zoomed insets.
+
+#     Creates a multi-panel plot showing raw fluorescence signal and baseline-corrected
+#     dF/F trace. When zoom_duration is specified, includes three zoomed inset plots
+#     showing detailed views of the beginning, middle, and end of the recording session.
+
+#     Parameters
+#     ----------
+#     trace : NDArray
+#         Neuropil-corrected raw fluorescence trace
+#     baseline : NDArray
+#         Fitted baseline (F0) values
+#     dff_trace : NDArray
+#         Baseline-corrected dF/F trace (fractional units)
+#     frame_rate : float
+#         Frame rate in Hz
+#     roi_id : int
+#         Region of interest identifier for labeling the plot
+#     fig_path : str or Path
+#         Directory path where the output PNG file will be saved
+#     unique_id: str
+#         unique identifier
+#     zoom_duration : float, optional
+#         Duration in seconds for each zoomed inset window. If None or 0,
+#         creates a simpler 2-row layout without insets. If positive, creates
+#         a 3-row layout with inset zoom plots. Default is 60.0.
+
+#     Returns
+#     -------
+#     None
+#         Saves the plot as a PNG file to the specified path and closes the figure.
+
+#     Notes
+#     -----
+#     The function creates different layouts based on zoom_duration:
+
+#     - If zoom_duration is None or 0: 2 rows per channel (raw + dF/F)
+#     - If zoom_duration > 0: 3 rows per channel (raw + insets + dF/F)
+
+#     Inset windows show:
+#     - First: Beginning of recording (0 to zoom_duration seconds)
+#     - Middle: Center portion of recording
+#     - Last: End of recording (last zoom_duration seconds)
+
+#     The saved filename follows the pattern: '{unique_id}_{roi_id}_dff.png'
+#     """
+#     t = np.arange(len(trace)) / frame_rate
+#     show_insets = zoom_duration is not None and zoom_duration > 0
+
+#     # Create figure and axes
+#     if show_insets:
+#         fig, ax = plt.subplots(3, 1, figsize=(12, 3.5))
+#     else:
+#         fig, ax = plt.subplots(2, 1, figsize=(12, 2.3), sharex=True)
+
+#     # Calculate row indices based on layout
+#     raw_idx = 0
+#     dff_idx = 2 if show_insets else 1
+#     inset_idx = 1 if show_insets else None
+
+#     # Plot raw signal
+#     ax[raw_idx].plot(t, trace, label="neuropil-corrected trace", c="C0", lw=0.5)
+#     ax[raw_idx].plot(t, baseline, label=r"fitted F$_0$", c="#F0E442")
+#     ax[raw_idx].legend(
+#         loc=(0.692, 0.78), ncol=2, borderpad=0.05
+#     ).get_frame().set_linewidth(0.0)
+#     ax[raw_idx].set_ylabel("F [a.u.]")
+
+#     # Plot dF/F signal
+#     ax[dff_idx].plot(t, dff_trace * 100, label=r"$\Delta$F/F", c="C2", zorder=-1, lw=0.5)
+#     ax[dff_idx].axhline(0, c="k", ls="--")
+#     ax[dff_idx].legend(
+#         loc=(0.923, 0.78), ncol=1, borderpad=0.05
+#     ).get_frame().set_linewidth(0.0)
+#     ax[dff_idx].set_ylabel(r"$\Delta$F/F [%]", y=1 if show_insets else 0.5)
+
+#     # Add insets if requested
+#     if show_insets:
+#         t_total = t[-1] - t[0]
+#         zoom_windows = [
+#             (t[0], t[0] + zoom_duration),
+#             (
+#                 t[0] + (t_total - zoom_duration) / 2,
+#                 t[0] + (t_total + zoom_duration) / 2,
+#             ),
+#             (max(t[-1] - zoom_duration, t[0]), t[-1]),
+#         ]
+
+#         ax[inset_idx].axis("off")
+
+#         for j, (start_time, end_time) in enumerate(zoom_windows):
+#             inset_ax = inset_axes(
+#                 ax[inset_idx],
+#                 width="100%",
+#                 height="100%",
+#                 loc="center",
+#                 bbox_to_anchor=([0.01, 0.34, 0.67][j], 0.0, 0.32, 0.8),
+#                 bbox_transform=ax[inset_idx].transAxes,
+#             )
+
+#             mask = (t >= start_time) & (t <= end_time)
+#             if np.any(mask):
+#                 t_zoom, dff_zoom = t[mask], dff_trace[mask] * 100
+
+#                 inset_ax.plot(t_zoom, dff_zoom, c="C2", lw=0.5)
+#                 inset_ax.axhline(0, c="k", ls="--")
+#                 inset_ax.grid(True, alpha=0.8)
+#                 inset_ax.set_xlim(start_time, end_time)
+
+#                 if len(dff_zoom) > 0:
+#                     mi, ma = np.nanmin(dff_zoom), np.nanmax(dff_zoom)
+#                     y_margin = 0.1 * (ma - mi)
+#                     if ~np.isnan(y_margin):
+#                         inset_ax.set_ylim(mi - y_margin, ma + y_margin)
+
+#                 inset_ax.set_title(
+#                     f"{['First', 'Middle', 'Last'][j]} {zoom_duration:.0f}s",
+#                     fontsize=10,
+#                     y=0.94,
+#                 )
+#                 inset_ax.set_xticks([])
+#                 inset_ax.set_yticks([])
+
+#                 mark_inset(
+#                     ax[dff_idx],
+#                     inset_ax,
+#                     loc1=1,
+#                     loc2=3,
+#                     fc="none",
+#                     ec="#333333",
+#                     alpha=0.8,
+#                     linestyle="--",
+#                     linewidth=1,
+#                 )
+
+#     # Set x-limits and labels
+#     tmin, tmax = np.nanmin(t), np.nanmax(t)
+#     margin = (tmax - tmin) / 100
+#     ax[raw_idx].set_xlim(tmin - margin, tmax + margin)
+#     ax[dff_idx].set_xlim(tmin - margin, tmax + margin)
+#     plt.setp(ax[raw_idx].get_xticklabels(), visible=False)
+#     ax[dff_idx].set_xlabel("Time [s]")
+#     ax[0].set_title(f"cell_roi_id: {int(roi_id)}")
+#     plt.subplots_adjust(hspace=0.1, top=0.935, bottom=0.13, left=0.06, right=0.995)
+#     fig.savefig(
+#         fig_path / f"{unique_id}_{roi_id}_dff.png",
+#         dpi=200,
+#         bbox_inches="tight",
+#         pad_inches=0.02,
+#     )
+#     plt.close(fig)
+
+
 def plot_dff(
     trace: NDArray,
     baseline: NDArray,
-    dff_trace: NDArray,
     frame_rate: float,
     roi_id: int,
-    fig_path: Union[str, Path],
+    fig_path: str | Path,
     unique_id: str,
+    log: dict | None = None,
     zoom_duration: float = 60.0,
 ) -> None:
-    """Plot raw and dF/F traces with optional zoomed insets.
-
-    Creates a multi-panel plot showing raw fluorescence signal and baseline-corrected
-    dF/F trace. When zoom_duration is specified, includes three zoomed inset plots
-    showing detailed views of the beginning, middle, and end of the recording session.
-
-    Parameters
-    ----------
-    trace : NDArray
-        Neuropil-corrected raw fluorescence trace
-    baseline : NDArray
-        Fitted baseline (F0) values
-    dff_trace : NDArray
-        Baseline-corrected dF/F trace (fractional units)
-    frame_rate : float
-        Frame rate in Hz
-    roi_id : int
-        Region of interest identifier for labeling the plot
-    fig_path : str or Path
-        Directory path where the output PNG file will be saved
-    unique_id: str
-        unique identifier
-    zoom_duration : float, optional
-        Duration in seconds for each zoomed inset window. If None or 0,
-        creates a simpler 2-row layout without insets. If positive, creates
-        a 3-row layout with inset zoom plots. Default is 60.0.
-
-    Returns
-    -------
-    None
-        Saves the plot as a PNG file to the specified path and closes the figure.
-
-    Notes
-    -----
-    The function creates different layouts based on zoom_duration:
-
-    - If zoom_duration is None or 0: 2 rows per channel (raw + dF/F)
-    - If zoom_duration > 0: 3 rows per channel (raw + insets + dF/F)
-
-    Inset windows show:
-    - First: Beginning of recording (0 to zoom_duration seconds)
-    - Middle: Center portion of recording
-    - Last: End of recording (last zoom_duration seconds)
-
-    The saved filename follows the pattern: '{unique_id}_{roi_id}_dff.png'
-    """
+    """Thin wrapper around :func:`aind_ophys_utils.dff.plot_dff` that handles
+    frame-rate-to-time conversion, triexp log annotation, and saving to disk."""
     t = np.arange(len(trace)) / frame_rate
-    show_insets = zoom_duration is not None and zoom_duration > 0
-
-    # Create figure and axes
-    if show_insets:
-        fig, ax = plt.subplots(3, 1, figsize=(12, 3.5))
-    else:
-        fig, ax = plt.subplots(2, 1, figsize=(12, 2.3), sharex=True)
-
-    # Calculate row indices based on layout
-    raw_idx = 0
-    dff_idx = 2 if show_insets else 1
-    inset_idx = 1 if show_insets else None
-
-    # Plot raw signal
-    ax[raw_idx].plot(t, trace, label="neuropil-corrected trace", c="C0", lw=0.5)
-    ax[raw_idx].plot(t, baseline, label=r"fitted F$_0$", c="#F0E442")
-    ax[raw_idx].legend(
-        loc=(0.692, 0.78), ncol=2, borderpad=0.05
-    ).get_frame().set_linewidth(0.0)
-    ax[raw_idx].set_ylabel("F [a.u.]")
-
-    # Plot dF/F signal
-    ax[dff_idx].plot(t, dff_trace * 100, label=r"$\Delta$F/F", c="C2", zorder=-1, lw=0.5)
-    ax[dff_idx].axhline(0, c="k", ls="--")
-    ax[dff_idx].legend(
-        loc=(0.923, 0.78), ncol=1, borderpad=0.05
-    ).get_frame().set_linewidth(0.0)
-    ax[dff_idx].set_ylabel(r"$\Delta$F/F [%]", y=1 if show_insets else 0.5)
-
-    # Add insets if requested
-    if show_insets:
-        t_total = t[-1] - t[0]
-        zoom_windows = [
-            (t[0], t[0] + zoom_duration),
-            (
-                t[0] + (t_total - zoom_duration) / 2,
-                t[0] + (t_total + zoom_duration) / 2,
-            ),
-            (max(t[-1] - zoom_duration, t[0]), t[-1]),
-        ]
-
-        ax[inset_idx].axis("off")
-
-        for j, (start_time, end_time) in enumerate(zoom_windows):
-            inset_ax = inset_axes(
-                ax[inset_idx],
-                width="100%",
-                height="100%",
-                loc="center",
-                bbox_to_anchor=([0.01, 0.34, 0.67][j], 0.0, 0.32, 0.8),
-                bbox_transform=ax[inset_idx].transAxes,
-            )
-
-            mask = (t >= start_time) & (t <= end_time)
-            if np.any(mask):
-                t_zoom, dff_zoom = t[mask], dff_trace[mask] * 100
-
-                inset_ax.plot(t_zoom, dff_zoom, c="C2", lw=0.5)
-                inset_ax.axhline(0, c="k", ls="--")
-                inset_ax.grid(True, alpha=0.8)
-                inset_ax.set_xlim(start_time, end_time)
-
-                if len(dff_zoom) > 0:
-                    mi, ma = np.nanmin(dff_zoom), np.nanmax(dff_zoom)
-                    y_margin = 0.1 * (ma - mi)
-                    if ~np.isnan(y_margin):
-                        inset_ax.set_ylim(mi - y_margin, ma + y_margin)
-
-                inset_ax.set_title(
-                    f"{['First', 'Middle', 'Last'][j]} {zoom_duration:.0f}s",
-                    fontsize=10,
-                    y=0.94,
-                )
-                inset_ax.set_xticks([])
-                inset_ax.set_yticks([])
-
-                mark_inset(
-                    ax[dff_idx],
-                    inset_ax,
-                    loc1=1,
-                    loc2=3,
-                    fc="none",
-                    ec="#333333",
-                    alpha=0.8,
-                    linestyle="--",
-                    linewidth=1,
-                )
-
-    # Set x-limits and labels
-    tmin, tmax = np.nanmin(t), np.nanmax(t)
-    margin = (tmax - tmin) / 100
-    ax[raw_idx].set_xlim(tmin - margin, tmax + margin)
-    ax[dff_idx].set_xlim(tmin - margin, tmax + margin)
-    plt.setp(ax[raw_idx].get_xticklabels(), visible=False)
-    ax[dff_idx].set_xlabel("Time [s]")
-    ax[0].set_title(f"cell_roi_id: {int(roi_id)}")
-    plt.subplots_adjust(hspace=0.1, top=0.935, bottom=0.13, left=0.06, right=0.995)
+    fig = dff.plot_dff(trace, baseline, t, zoom_duration=zoom_duration, roi_id=roi_id)
+    fig.set_size_inches(12, 3.5 if zoom_duration else 2.3)
+    fig.axes[0].get_lines()[1].set_color("#F0E442")
+    title = f"cell_roi_id: {int(roi_id)}"
+    if log is not None:
+        title += (
+            f"  (n_passes={log.get('n_passes')}, "
+            f"winner={log.get('winner_combo')}, "
+            f"trigger={log.get('pass1_trigger')})"
+        )
+    fig.axes[0].set_title(title)
     fig.savefig(
-        fig_path / f"{unique_id}_{roi_id}_dff.png",
+        Path(fig_path) / f"{unique_id}_{roi_id}_dff.png",
         dpi=200,
         bbox_inches="tight",
         pad_inches=0.02,
@@ -445,8 +478,7 @@ if __name__ == "__main__":
                 plot_dff,
                 zip(
                     traces,
-                    baseline,
-                    dff_traces,
+                    np.maximum(baseline, noise[:, None]),
                     [frame_rate] * N,
                     [f"{n:0{len(str(N))}d}" for n in range(N)],
                     [fig_path] * N,

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -13,16 +13,18 @@ COPY git-ask-pass /
 
 ENV DFF_EXTRACTION_URL=https://github.com/AllenNeuralDynamics/aind-ophys-dff
 
-RUN --mount=type=secret,id=git-access-token \
-    GIT_ACCESS_TOKEN="$(cat /run/secrets/git-access-token)" \
-    pip3 install -U --no-cache-dir \
+RUN pip3 install -U --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu \
-    # aind-ophys-utils \
-    git+https://github.com/AllenNeuralDynamics/aind-ophys-utils.git@plot-dff-style  \
+    git+https://github.com/AllenNeuralDynamics/aind-ophys-utils.git@fix/percentile-filter-negative-size \
     aind-data-schema==1.2.0 \
     aind-data-schema-models==0.7.5 \
     aind-log-utils==0.2.8 \
     aind-qcportal-schema==0.4.0 \
     matplotlib==3.10.9 \
     pydantic-settings==2.14.1 \
+    joblib
+
+RUN --mount=type=secret,id=git-access-token \
+    GIT_ACCESS_TOKEN="$(cat /run/secrets/git-access-token)" \
+    pip3 install --no-cache-dir --no-deps \
     -e git+https://github.com/AllenNeuralDynamics/aind-ophys-dff-library.git@v0.1.0#egg=aind-ophys-dff-library

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,23 +1,20 @@
-FROM registry.codeocean.allenneuraldynamics.org/codeocean/jupyterlab:3.4.4-miniconda4.12.0-python3.9-ubuntu20.04
+# hash:sha256:0e951733d816fe6b42cbaffc702a88a983e354f0131ce0b6bc1ec64499b500e5
+ARG REGISTRY_HOST
+FROM $REGISTRY_HOST/codeocean/mambaforge3:24.5.0-0-python3.12.4-ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV PIPELINE_URL="https://codeocean.allenneuraldynamics.org/capsule/5619253/tree"
-ENV PIPELINE_VERSION="1.0"
 ENV VERSION="6.0"
 
 ARG GIT_ASKPASS
 ARG GIT_ACCESS_TOKEN
-COPY git-askpass /
+COPY git-ask-pass /
 
 ENV DFF_EXTRACTION_URL=https://github.com/AllenNeuralDynamics/aind-ophys-dff
 
-RUN ["apt-get", "update"]
-RUN ["apt-get", "install", "-y", "vim"]
 RUN pip3 install -U --no-cache-dir \
-    torch --index-url https://download.pytorch.org/whl/cpu
-
-RUN pip3 install -U --no-cache-dir \
+    --extra-index-url https://download.pytorch.org/whl/cpu \
     aind-ophys-utils \
     aind-data-schema==1.2.0 \
     aind-log-utils \

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -15,7 +15,8 @@ ENV DFF_EXTRACTION_URL=https://github.com/AllenNeuralDynamics/aind-ophys-dff
 
 RUN pip3 install -U --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu \
-    aind-ophys-utils \
+    # aind-ophys-utils \
+    git+https://github.com/AllenNeuralDynamics/aind-ophys-utils.git@plot-dff-style  \
     aind-data-schema==1.2.0 \
     aind-log-utils \
     aind-qcportal-schema \


### PR DESCRIPTION
## Summary

Refactors `dff.py`'s plotting to delegate to [`aind-ophys-utils`](https://github.com/AllenNeuralDynamics/aind-ophys-utils)`.dff.plot_dff`, removing ~150 lines of duplicated inline matplotlib code:

- Replace inline `plot_dff` body with a thin wrapper around `aind_ophys_utils.dff.plot_dff` (overhauled aesthetics, mathtext labels, 4-panel full-baseline mode), keeping this file's own frame-rate-to-time conversion, triexp log annotation, and figure-saving.
- Update `Dockerfile` to pull the new dependency.

## Dependency

> ⚠️ The Dockerfile currently pins `aind-ophys-utils` to [`fix/percentile-filter-negative-size`](https://github.com/AllenNeuralDynamics/aind-ophys-utils/pull/77) (a fix for a silent wrong-shaped-array bug in `percentile_filter` found while testing this dF/F path) as a stopgap. Merge sequence before this PR is ready:
>
> 1. Merge [aind-ophys-utils#77](https://github.com/AllenNeuralDynamics/aind-ophys-utils/pull/77) into `dev`.
> 2. Merge [aind-ophys-utils#72](https://github.com/AllenNeuralDynamics/aind-ophys-utils/pull/72) (`dev` → `main`) -- this push auto-triggers a version bump + PyPI publish.
> 3. Once the new version is live on PyPI, update this PR's Dockerfile from the branch reference to a pinned `aind-ophys-utils==<version>`.
> 4. Then merge this PR.

## Test plan

- [ ] dF/F output matches previous implementation
- [ ] `plot_dff` renders correctly for both 2-panel and 4-panel modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)